### PR TITLE
externpro 26.01-32-g3071d2c

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,0 +1,4 @@
+{
+  "message": "xpro version 2.4.2.4 tag",
+  "tag": "xpv2.4.2.4"
+}

--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,0 @@
-tag: xpv2.4.2.3
-message: "xpro version 2.4.2.3 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,11 +14,15 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
-    secrets: inherit
+    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01
+    secrets:
+      automation_token: ${{ secrets.GHCR_TOKEN }}
+    with: {}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01
     secrets: inherit
+    with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01
     secrets: inherit
+    with: {}

--- a/.github/workflows/xpinit.yml
+++ b/.github/workflows/xpinit.yml
@@ -1,0 +1,12 @@
+name: xpInit externpro
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+on:
+  workflow_dispatch:
+jobs:
+  init:
+    uses: externpro/externpro/.github/workflows/init-externpro.yml@main
+    secrets:
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
-      workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.31)
-set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES .devcontainer/cmake/xproinc.cmake)
+cmake_minimum_required(VERSION 4.3)
 project(geotranz)
 set(lib_name ${PROJECT_NAME})
 #######################################
@@ -172,23 +171,22 @@ if(MSVC)
 endif()
 #######################################
 set(targetsFile ${PROJECT_NAME}-targets)
-if(DEFINED XP_NAMESPACE)
+if(COMMAND xpExternPackage)
   string(TOUPPER ${PROJECT_NAME} PRJ)
   string(JOIN "\n" EXT3
-    "get_target_property(incDir ${XP_NAMESPACE}::${lib_name} INTERFACE_INCLUDE_DIRECTORIES)"
+    "get_target_property(incDir ${PROJECT_NAME}::${lib_name} INTERFACE_INCLUDE_DIRECTORIES)"
     "set(${PRJ}_DATA_DIR \${incDir}/${PROJECT_NAME}/data)"
     "list(APPEND reqVars ${PRJ}_DATA_DIR)"
     ""
     )
-  xpExternPackage(NAMESPACE ${XP_NAMESPACE}
-    TARGETS_FILE ${targetsFile} LIBRARIES ${lib_name}
+  xpExternPackage(TARGETS_FILE ${targetsFile} PKG_CMAKE_USEXT
+    LIBRARIES ${lib_name} DEFAULT_TARGETS ${lib_name}
     BASE v2.4.2 XPDIFF "intro"
     WEB "https://earth-info.nga.mil"
     DESC "geographic translator (convert coordinates)"
     LICENSE "[LicenseRef-NGA-GEOTRANS-Terms-Of-Use](https://github.com/externpro/geotranz/blob/xpro/readme.txt 'GEOTRANS Terms of Use')"
     ATTRIBUTION "The product was developed using GEOTRANS, a product of the National Geospatial-Intelligence Agency (NGA) and U.S. Army Engineering Research and Development Center."
     )
-  set(nameSpace NAMESPACE ${XP_NAMESPACE}::)
 elseif(NOT DEFINED CMAKE_INSTALL_CMAKEDIR)
   set(CMAKE_INSTALL_CMAKEDIR ${CMAKE_INSTALL_DATADIR}/cmake)
 endif()
@@ -200,4 +198,4 @@ install(TARGETS ${lib_name} EXPORT ${targetsFile}
 install(FILES ${lib_hdrs} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 list(TRANSFORM csvFile PREPEND ${csvDir}/)
 install(FILES ${geotrans2_data} ${csvFile} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/data)
-install(EXPORT ${targetsFile} DESTINATION ${CMAKE_INSTALL_CMAKEDIR} ${nameSpace})
+install(EXPORT ${targetsFile} DESTINATION ${CMAKE_INSTALL_CMAKEDIR} NAMESPACE ${PROJECT_NAME}::)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,7 @@
   "include": [
     ".devcontainer/cmake/presets/xpLinuxNinja.json",
     ".devcontainer/cmake/presets/xpDarwinNinja.json",
-    ".devcontainer/cmake/presets/xpWindowsVs2022.json"
+    ".devcontainer/cmake/presets/xpMswVs2022.json",
+    ".devcontainer/cmake/presets/xpMswVs2026.json"
   ]
 }

--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -6,7 +6,7 @@
       "hidden": true,
       "binaryDir": "${sourceDir}/_bld-${presetName}",
       "cacheVariables": {
-        "XP_NAMESPACE": "xpro"
+        "CMAKE_EXPERIMENTAL_GENERATE_SBOM": "ca494ed3-b261-4205-a01f-603c95e4cae0"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01-32-g3071d2c`

## Changes

- Updated `.devcontainer` to externpro `26.01-32-g3071d2c`
- Previous HEAD: `f0e88b29cf1fc02f24a6aeae49750276231c920a`
- New HEAD: `3071d2c840834352ba79cbed6f6c30625555310c`
- Created `.github/release-tag.json` (tag: `xpv2.4.2.4`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv2.4.2.4\`
- Updated caller workflows to match templates
- CMakePresets.json review needed
  - See details below

### Workflow Update Report

- ✓ xpbuild.yml: Synced from template
- ✓ xpinit.yml: Created new workflow from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

### CMakePresets.json

- Auto-fix: replaced `.devcontainer/cmake/presets/xpWindowsVs2022.json` include and staged `CMakePresets.json`

---

*This PR was created automatically by GitHub Actions*
